### PR TITLE
9 merchant item disableenable

### DIFF
--- a/app/controllers/merchants/items_controller.rb
+++ b/app/controllers/merchants/items_controller.rb
@@ -17,7 +17,10 @@ class Merchants::ItemsController < ApplicationController
   def update
     @item = Item.find(params[:id])
     @merchant = Merchant.find(params[:merchant_id])
-      if @item.update(item_params)
+      if params[:enabled].present?
+        @item.update(enabled: params[:enabled])
+        redirect_to merchant_items_path(@merchant)
+      elsif @item.update(item_params)
         redirect_to merchant_item_path(@merchant, @item)
         flash[:success] = "Item was successfully updated"
       else

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -21,4 +21,12 @@ class Item < ApplicationRecord
       formatted_price
   end
 
+  def self.enabled
+    where(enabled: true)
+  end
+
+  def self.disabled
+    where(enabled: false)
+  end
+
 end

--- a/app/views/merchants/items/index.html.erb
+++ b/app/views/merchants/items/index.html.erb
@@ -1,6 +1,49 @@
 <h1>Welcome <%= @merchant.name %></h1>
 <h1> Your Items </h1>
 
-<% @merchant.items.each do |item| %>
-  <li><%=link_to item.name, merchant_item_path(@merchant, item) %>
-<% end %>
+
+<div class="table-container">
+  <table class="enabled">
+    <caption class="ena">Enabled Items</caption>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Status</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @merchant.items.enabled.each do |item| %>
+        <tr id="ei-<%= item.id %>">
+          <td><%= link_to item.name, merchant_item_path(@merchant, item) %></td>
+          <td>Enabled</td>
+          <td>
+            <%= button_to "Disable Item", merchant_item_path(@merchant, item), method: :patch, params: { enabled: false } %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <table class="disabled">
+    <caption class="dis">Disabled Items</caption>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Status</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @merchant.items.disabled.each do |item| %>
+        <tr id="di-<%= item.id %>">
+          <td><%= link_to item.name, merchant_item_path(@merchant, item) %></td>
+          <td>Disabled</td>
+          <td>
+            <%= button_to "Enable Item", merchant_item_path(@merchant, item), method: :patch, params: { enabled: true } %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/spec/features/merchants/items/edit_spec.rb
+++ b/spec/features/merchants/items/edit_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "items edit page", type: :feature do
       fill_in("Name", with: "cheeese")
       expect(page).to have_field("Description", with: "its cheese.")
       expect(page).to have_field("Unit price", with: "1337")
+  
       click_button "Submit"
 
       expect(current_path).to eq(merchant_item_path(@merchant1, @item1))

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe "items index page", type: :feature do
     @merchant1 = Merchant.create!(name: "Safeway")
     @merchant2 = Merchant.create!(name: "Spatula City")
 
-    @item1 = Item.create!(name: "cheese", description: "its cheese.", unit_price: 1337, merchant_id: @merchant1.id)
-    @item2 = Item.create!(name: "bad cheese", description: "its cheese.", unit_price: 1337, merchant_id: @merchant1.id)
-    @item3 = Item.create!(name: "Bacon", description: "its bacon.", unit_price: 2337, merchant_id: @merchant1.id)
-    @item4 = Item.create!(name: "Chowda", description: "say it right.", unit_price: 5537, merchant_id: @merchant2.id)
+    @item1 = Item.create!(name: "cheese", description: "its cheese.", unit_price: 1337, merchant_id: @merchant1.id, enabled: true)
+    @item2 = Item.create!(name: "bad cheese", description: "its cheese.", unit_price: 1337, merchant_id: @merchant1.id, enabled: true)
+    @item3 = Item.create!(name: "Bacon", description: "its bacon.", unit_price: 2337, merchant_id: @merchant1.id, enabled: false)
+    @item4 = Item.create!(name: "Chowda", description: "say it right.", unit_price: 5537, merchant_id: @merchant2.id, enabled: false)
   end
 
   describe "merchant items index page" do
@@ -33,12 +33,75 @@ RSpec.describe "items index page", type: :feature do
       click_link ("#{@item1.name}")
       expect(current_path).to eq(merchant_item_path(@merchant1, @item1))
     end
+
+    it "should have a button to disable or enable next to item name" do
+      visit merchant_items_path(@merchant1)
+
+      within("tr#ei-#{@item1.id}") do
+        expect(page).to have_content("Enabled")
+        expect(page).to_not have_content("Disabled")
+        expect(page).to have_button("Disable Item")
+      end
+
+      within("tr#ei-#{@item2.id}") do
+        expect(page).to have_content("Enabled")
+        expect(page).to_not have_content("Disabled")
+        expect(page).to have_button("Disable Item")
+      end
+
+      within("tr#di-#{@item3.id}") do
+        expect(page).to have_content("Disabled")
+        expect(page).to_not have_content("Enabled")
+        expect(page).to have_button("Enable Item")
+      end
+
+    end
+
+    it "should have enabled and disabled sections that update" do
+      visit merchant_items_path(@merchant1)
+
+      within(".enabled") do
+        expect(page).to have_content("Enabled Items")
+        expect(page).to have_content("cheese")
+        expect(page).to have_content("bad cheese")
+        expect(page).to_not have_content("Bacon")
+      end
+
+      within(".disabled") do
+        expect(page).to have_content("Disabled Items")
+        expect(page).to have_content("Bacon")
+        expect(page).to_not have_content("cheese")
+      end
+      
+      within("tr#ei-#{@item2.id}") do
+        click_button("Disable Item")
+      end
+      
+      within("tr#di-#{@item3.id}") do
+        click_button("Enable Item")
+      end
+
+
+      within(".enabled") do
+        expect(page).to have_content("cheese")
+        expect(page).to_not have_content("bad cheese")
+        expect(page).to have_content("Bacon")
+      end
+
+      within(".disabled") do
+        expect(page).to_not have_content("Bacon")
+        expect(page).to have_content("bad cheese")
+      end
+    end
   end
 
 end
 
-# 6. Merchant Items Index Page
-# As a merchant,
-# When I visit my merchant items index page (merchants/:merchant_id/items)
-# I see a list of the names of all of my items
-# And I do not see items for any other merchant
+# 9. Merchant Item Disable/Enable
+
+# As a merchant
+# When I visit my items index page (/merchants/:merchant_id/items)
+# Next to each item name I see a button to disable or enable that item.
+# When I click this button
+# Then I am redirected back to the items index
+# And I see that the items status has changed

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Invoice, type: :model do
     date_array = full_date.split
     weekdays = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
     months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
-    days = (1...31).to_a
+    days = (1..31).to_a
     expect(weekdays).to include(date_array[0])
     expect(months).to include(date_array[1])
     expect(days).to include(date_array[2].to_i)

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Item, type: :model do
       @customer6 = Customer.create!(first_name: "Johnny", last_name: "Smith")
       @customer7 = Customer.create!(first_name: "Joseph", last_name: "Smith")
 
-      @item1 = Item.create!(name: "cheese", description: "its cheese.", unit_price: 1337, merchant_id: @merchant1.id)
-      @item2 = Item.create!(name: "golden eggs", description: "real gold yo.", unit_price: 38432112, merchant_id: @merchant1.id)
+      @item1 = Item.create!(name: "cheese", description: "its cheese.", unit_price: 1337, merchant_id: @merchant1.id, enabled: true)
+      @item2 = Item.create!(name: "golden eggs", description: "real gold yo.", unit_price: 38432112, merchant_id: @merchant1.id, enabled: false)
 
       @invoice1 = Invoice.create!(status: "completed", customer_id: @customer1.id)
       @invoice2 = Invoice.create!(status: "completed", customer_id: @customer2.id)
@@ -63,6 +63,19 @@ RSpec.describe Item, type: :model do
       expect(@item1.formatted_unit_price).to eq("$13.37")
       expect(@item2.formatted_unit_price).to eq("$384,321.12")
       expect(@item1.formatted_unit_price).to_not eq(1337)
+    end
+  end
+    
+  describe "#enabled" do
+    it "returns only enabled items" do
+      expect(@merchant1.items.enabled).to eq([@item1])
+    end
+  end
+  
+  describe "#disabled" do
+    it "returns only disabled items" do
+      expect(@merchant1.items.disabled).to eq([@item2])
+
     end
   end
 


### PR DESCRIPTION
Complete user story 9 and 10 and completes issues #11 and #12 

Created enabled and disabled methods that returns all items with a enabled or disable status

created buttons to disable and enable items

adds super cool view to show items enabled or disabled with functionality to move enabled to disabled table if status is changed

updated the update method in the item controller to redirect to the merchants/items page if status is changed

Add functionality for enable and disable items in items update