### PR TITLE
Format money refactor

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,8 +1,9 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
 
-  def format_money(value)
-    amount = value/100.00
+  def format_money(*attributes) #may be one method, or a method + argument
+    amount = self.send(*attributes)/100.to_f
+
     formatted_amount = sprintf("$%.2f", amount)
     if formatted_amount.length > 7
       formatted_amount = formatted_amount.gsub!(/(\d)(?=(\d{3})+(?!\d))/, "\\1,")

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,7 +1,7 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
 
-  def format_money(*attributes) #may be one method, or a method + argument
+  def format_money(*attributes)
     amount = self.send(*attributes)/100.to_f
 
     formatted_amount = sprintf("$%.2f", amount)

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -10,12 +10,12 @@ Customer: <%= @invoice.customer.full_name %>
 
 
 <h3>Items on this order:</h3>
-<p>Total For This Invoice: <%= @invoice.format_money(@invoice.total_revenue) %></p>
+<p>Total For This Invoice: <%= @invoice.format_money(:total_revenue) %></p>
 <% @invoice.invoice_items.each do |invoice_item| %>
   <div id="item-<%=invoice_item.id%>">
     Item: <%= invoice_item.item.name %><br>
     Quantity Ordered: <%= invoice_item.quantity %><br>
-    Sold at: <%= invoice_item.format_money(invoice_item.unit_price) %> per unit
+    Sold at: <%= invoice_item.format_money(:unit_price) %> per unit
     Item Status: <%= invoice_item.status %>
   </div>
   <br>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -5,7 +5,7 @@
   <h2>Top Five Merchants By Total Revenue</h2>
   <% Merchant.top_5_by_total_revenue.each do |merchant| %>
     <section id="merchant-<%= merchant.id %>">
-      <%= link_to merchant.name, admin_merchant_path(merchant) %> - Total Revenue: <%= merchant.format_money(merchant.total_revenue) %>
+      <%= link_to merchant.name, admin_merchant_path(merchant) %> - Total Revenue: <%= merchant.format_money(:total_revenue) %>
       <p>Top selling date for <%= merchant.name %> was <%= merchant.best_day %></p>
       <br>
     </section>

--- a/app/views/merchants/invoices/show.html.erb
+++ b/app/views/merchants/invoices/show.html.erb
@@ -6,12 +6,12 @@
 
 
 <h3>Items on this order:</h3>
-<p>Total For This Invoice: <%= @invoice.format_money(@invoice.revenue_for(@merchant)) %></p>
+<p>Total For This Invoice: <%= @invoice.format_money(:revenue_for, @merchant) %></p>
 <% @invoice.invoice_items_for(@merchant).each do |invoice_item| %>
   <div id="item-<%=invoice_item.id%>">
     Item: <%= invoice_item.item.name %><br>
     Quantity Ordered: <%= invoice_item.quantity %><br>
-    Sold at: <%= invoice_item.format_money(invoice_item.unit_price) %> per unit
+    Sold at: <%= invoice_item.format_money(:unit_price) %> per unit
     <%= form_with url: merchant_invoice_item_path(@merchant, invoice_item), method: :patch, local: true do |f| %>
       <%= f.label "Status:" %>
       <%= f.select :status, ["pending", "shipped", "packaged"], selected: invoice_item.status %>

--- a/app/views/merchants/items/edit.html.erb
+++ b/app/views/merchants/items/edit.html.erb
@@ -2,7 +2,7 @@
 
 <p>Name: <%= @item.name %></p>
 <p>Description: <%= @item.description %></p>
-<p>Current Selling Price: <%= @item.format_money(@item.unit_price) %></p>
+<p>Current Selling Price: <%= @item.format_money(:unit_price) %></p>
 
 <%= form_with url: merchant_item_path(@merchant, @item), method: :patch, local: true do |f| %>
   <%= f.label :name %>

--- a/app/views/merchants/items/show.html.erb
+++ b/app/views/merchants/items/show.html.erb
@@ -4,5 +4,5 @@
 
 <p>Name: <%= @item.name %></p>
 <p>Description: <%= @item.description %></p>
-<p>Current Selling Price: <%= @item.format_money(@item.unit_price) %></p>
+<p>Current Selling Price: <%= @item.format_money(:unit_price) %></p>
 <p><%= link_to "Update Item", edit_merchant_item_path(@merchant, @item) %></p>

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -192,27 +192,27 @@ RSpec.describe "Admin Merchants Index Page" do
     within("#top_five") do
       within("#merchant-#{@merchant6.id}") do
         expect(page).to have_link("#{@merchant6.name}", href: admin_merchant_path(@merchant6))
-        expect(page).to have_content("Total Revenue: #{@merchant6.format_money(@merchant6.total_revenue)}")
+        expect(page).to have_content("Total Revenue: #{@merchant6.format_money(:total_revenue)}")
       end
 
       within("#merchant-#{@merchant2.id}") do
         expect(page).to have_link("#{@merchant2.name}", href: admin_merchant_path(@merchant2))
-        expect(page).to have_content("Total Revenue: #{@merchant2.format_money(@merchant2.total_revenue)}")
+        expect(page).to have_content("Total Revenue: #{@merchant2.format_money(:total_revenue)}")
       end
 
       within("#merchant-#{@merchant4.id}") do
         expect(page).to have_link("#{@merchant4.name}", href: admin_merchant_path(@merchant4))
-        expect(page).to have_content("Total Revenue: #{@merchant4.format_money(@merchant4.total_revenue)}")
+        expect(page).to have_content("Total Revenue: #{@merchant4.format_money(:total_revenue)}")
       end 
 
       within("#merchant-#{@merchant5.id}") do
         expect(page).to have_link("#{@merchant5.name}", href: admin_merchant_path(@merchant5))
-        expect(page).to have_content("Total Revenue: #{@merchant5.format_money(@merchant5.total_revenue)}")
+        expect(page).to have_content("Total Revenue: #{@merchant5.format_money(:total_revenue)}")
       end
       
       within("#merchant-#{@merchant7.id}") do
         expect(page).to have_link("#{@merchant7.name}", href: admin_merchant_path(@merchant7))
-        expect(page).to have_content("Total Revenue: #{@merchant7.format_money(@merchant7.total_revenue)}")
+        expect(page).to have_content("Total Revenue: #{@merchant7.format_money(:total_revenue)}")
       end
 
       expect(@merchant6.name).to appear_before(@merchant2.name)

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe ApplicationRecord do
+  before do
+    @merchant1 = Merchant.create!(name: "Dangerway", enabled: true)
+    @merchant2 = Merchant.create!(name: "Targete", enabled: true)
+
+    @customer1 = Customer.create!(first_name: "Bob", last_name: "Smith")
+
+    @item1 = Item.create!(name: "cheese", description: "its cheese.", unit_price: 1337, merchant_id: @merchant1.id)
+    @item2 = Item.create!(name: "bad cheese", description: "its cheese.", unit_price: 1337, merchant_id: @merchant2.id)
+
+    @invoice1 = Invoice.create!(status: "completed", customer_id: @customer1.id, created_at: Time.new(2011,4,5))
+    
+    @invoice_item1 = InvoiceItem.create!(item_id: @item1.id, invoice_id: @invoice1.id, quantity: 5, unit_price: 13635, status: "pending")
+    @invoice_item2 = InvoiceItem.create!(item_id: @item2.id, invoice_id: @invoice1.id, quantity: 9, unit_price: 23324, status: "pending")
+  end
+
+  describe "#format_money" do
+    it "can format money with a given argument" do
+      expect(@item1.format_money(:unit_price)).to eq("$13.37")
+      expect(@invoice1.format_money(:total_revenue)).to eq("$2,780.91")
+      expect(@invoice1.format_money(:revenue_for, @merchant1)).to eq("$681.75")
+    end
+  end
+end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -31,10 +31,10 @@ RSpec.describe InvoiceItem, type: :model do
       @invoice_item3 = InvoiceItem.create!(invoice: @invoice1, item: @item3, quantity: 465, unit_price: 34568765, status: "shipped")
       @invoice_item4 = InvoiceItem.create!(invoice: @invoice1, item: @item4, quantity: 23, unit_price: 1509, status: "shipped")
 
-      expect(@invoice_item1.format_money(@invoice_item1.unit_price)).to eq("$34.76")
-      expect(@invoice_item2.format_money(@invoice_item2.unit_price)).to eq("$8.02")
-      expect(@invoice_item3.format_money(@invoice_item3.unit_price)).to eq("$345,687.65")
-      expect(@invoice_item4.format_money(@invoice_item4.unit_price)).to eq("$15.09")
+      expect(@invoice_item1.format_money(:unit_price)).to eq("$34.76")
+      expect(@invoice_item2.format_money(:unit_price)).to eq("$8.02")
+      expect(@invoice_item3.format_money(:unit_price)).to eq("$345,687.65")
+      expect(@invoice_item4.format_money(:unit_price)).to eq("$15.09")
     end
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -75,9 +75,9 @@ RSpec.describe Invoice, type: :model do
   end
 
   it "formats the revenue" do
-    expect(@invoice1.format_money(@invoice1.total_revenue)).to eq("$1,614.71")
-    expect(@invoice2.format_money(@invoice2.total_revenue)).to eq("$2,099.16")
-    expect(@invoice6.format_money(@invoice6.total_revenue)).to eq("$4,198.32")
+    expect(@invoice1.format_money(:total_revenue)).to eq("$1,614.71")
+    expect(@invoice2.format_money(:total_revenue)).to eq("$2,099.16")
+    expect(@invoice6.format_money(:total_revenue)).to eq("$4,198.32")
   end
 
   it "can filter invoice items by merchant" do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -61,9 +61,9 @@ RSpec.describe Item, type: :model do
 
   describe "formatted unit price" do
     it "should return item price formatted in dollars and cents" do
-      expect(@item1.format_money(@item1.unit_price)).to eq("$13.37")
-      expect(@item2.format_money(@item2.unit_price)).to eq("$384,321.12")
-      expect(@item1.format_money(@item1.unit_price)).to_not eq(1337)
+      expect(@item1.format_money(:unit_price)).to eq("$13.37")
+      expect(@item2.format_money(:unit_price)).to eq("$384,321.12")
+      expect(@item1.format_money(:unit_price)).to_not eq(1337)
     end
   end
     

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -153,13 +153,13 @@ RSpec.describe Merchant, type: :model do
   end
 
   it "returns formatted total revenue" do
-    expect(@merchant1.format_money(@merchant1.total_revenue)).to eq("$14,776.20")
-    expect(@merchant2.format_money(@merchant2.total_revenue)).to eq("$1,658.26")
-    expect(@merchant3.format_money(@merchant3.total_revenue)).to eq("$64.53")
-    expect(@merchant4.format_money(@merchant4.total_revenue)).to eq("$543.88")
-    expect(@merchant5.format_money(@merchant5.total_revenue)).to eq("$367.24")
-    expect(@merchant6.format_money(@merchant6.total_revenue)).to eq("$4,348.36")
-    expect(@merchant7.format_money(@merchant7.total_revenue)).to eq("$130.16")
+    expect(@merchant1.format_money(:total_revenue)).to eq("$14,776.20")
+    expect(@merchant2.format_money(:total_revenue)).to eq("$1,658.26")
+    expect(@merchant3.format_money(:total_revenue)).to eq("$64.53")
+    expect(@merchant4.format_money(:total_revenue)).to eq("$543.88")
+    expect(@merchant5.format_money(:total_revenue)).to eq("$367.24")
+    expect(@merchant6.format_money(:total_revenue)).to eq("$4,348.36")
+    expect(@merchant7.format_money(:total_revenue)).to eq("$130.16")
   end
 
   it "returns top 5 merchants by total revenue generated" do


### PR DESCRIPTION
Previous pull request: squished `#formatted_price` and `#formatted_revenue` into one method, `#format_money`

Merging the methods involved adjusting the syntax of calling the method. Which ended up looking redundant and clunky, especially after adding a third money-type method `#revenue_for(merchant)`

This pull request:

- Changed `#format_money()` to accept symbols and objects as arguments, instead of integers
- Adjusted syntax on all instances of `format_money` in tests and views accordingly

Used `.send(:method)`, which allows for methods to be passed as arguments (in the form of symbols) to be used by other methods. Any additional arguments passed are then seen as arguments for the method. For example:

`item.format_money(:unit_price)` 

- within `format_money` is `self.send(:unit_price)` which is the same as `item.unit_price`

`invoice.format_money(:revenue_for, merchant)`

- within `format_money` is `self.send(:revenue_for, merchant)` which is the same as `invoice.revenue_for(merchant)`